### PR TITLE
Hubot schedule to talk to hubot

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Hubot> hubot schedule list
 Message is not scheduled
 
 Hubot> hubot schedule add "0 10 * * 1-5" hubot image me coffee
-9735: Schedule created
-(hubot can process messages sent by hubot-schedule, so you can ask hubot to do something at the scheduled time, like post an image of coffee. It will only work if you set `HUBOT_SCHEDULE_RECEIVE` environment variable to 1)
+9735: Schedule created v
+(hubot can process messages sent by hubot-schedule, so you can ask hubot to do something at the scheduled time, like post an image of coffee. You can disable it by setting `HUBOT_SCHEDULE_DONT_RECEIVE` environment variable to 1)
 ```
 
 If you are required to persist scheduled messages, use hubot-brain persistent module like [hubot-redis-brain](https://github.com/hubot-scripts/hubot-redis-brain).

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Hubot> hubot schedule del 9735
 
 Hubot> hubot schedule list
 Message is not scheduled
+
+Hubot> hubot schedule add "0 10 * * 1-5" hubot image me coffee
+9735: Schedule created
+(hubot can process messages sent by hubot-schedule, so you can ask hubot to do something at the scheduled time, like post an image of coffee. It will only work if you set `HUBOT_SCHEDULE_RECEIVE` environment variable to 1)
 ```
 
 If you are required to persist scheduled messages, use hubot-brain persistent module like [hubot-redis-brain](https://github.com/hubot-scripts/hubot-redis-brain).

--- a/src/scripts/schedule.coffee
+++ b/src/scripts/schedule.coffee
@@ -13,7 +13,7 @@
 
 scheduler = require('node-schedule')
 cronParser = require('cron-parser')
-
+{TextMessage} = require('../../../hubot')
 JOBS = {}
 JOB_MAX_COUNT = 10000
 STORE_KEY = 'hubot_schedule'
@@ -169,6 +169,7 @@ class Job
     @job = scheduler.scheduleJob(@pattern, =>
       envelope = user: @user, room: @user.room
       robot.send envelope, @message
+      robot.adapter.receive new TextMessage(@user, @message) if process.env.HUBOT_SCHEDULE_RECEIVE
       @cb?()
     )
 

--- a/src/scripts/schedule.coffee
+++ b/src/scripts/schedule.coffee
@@ -13,7 +13,7 @@
 
 scheduler = require('node-schedule')
 cronParser = require('cron-parser')
-{TextMessage} = require('../../../hubot')
+{TextMessage} = require('hubot')
 JOBS = {}
 JOB_MAX_COUNT = 10000
 STORE_KEY = 'hubot_schedule'
@@ -169,7 +169,7 @@ class Job
     @job = scheduler.scheduleJob(@pattern, =>
       envelope = user: @user, room: @user.room
       robot.send envelope, @message
-      robot.adapter.receive new TextMessage(@user, @message) if process.env.HUBOT_SCHEDULE_RECEIVE
+      robot.adapter.receive new TextMessage(@user, @message) unless process.env.HUBOT_SCHEDULE_DONT_RECEIVE
       @cb?()
     )
 


### PR DESCRIPTION
hey,

I was playing with `hubot-schedule` and I realized I cannot do such thing as `hubot schedule add "0 10 * * 1-5" hubot image me coffee`, so messages sent by `hubot-schedule` won't be processed by hubot. So I added this small feature.

You have to enable this functionality by setting `HUBOT_SCHEDULE_RECEIVE=1`.

Also the solution was borrowed from: https://github.com/Yoichi-KIKUCHI/hubot-link/blob/master/src/link.coffee#L73
