### PR TITLE
Adds optional configuration to prefix the schedule list with a string

### DIFF
--- a/src/scripts/schedule.coffee
+++ b/src/scripts/schedule.coffee
@@ -8,6 +8,9 @@
 #   hubot schedule [upd|update] <id> <message> - Update scheduled message
 #   hubot schedule list - List all scheduled messages
 #
+# Configuration:
+#   HUBOT_SCHEDULE_LIST_PREFIX
+#
 # Author:
 #   matsukaz
 
@@ -35,9 +38,9 @@ module.exports = (robot) ->
       if room in [msg.message.user.room, msg.message.user.reply_to]
         text += "#{id}: [ #{job.pattern} ] \##{room} #{job.message} \n"
     if !!text.length
-      msg.send text
+      msg.send "#{process.env.HUBOT_SCHEDULE_LIST_PREFIX || ""}#{text}"
     else
-      msg.send 'Message is not scheduled'
+      msg.send 'No messages have been scheduled'
 
   robot.respond /schedule (?:upd|update) (\d+) (.*)/i, (msg) ->
     updateSchedule robot, msg, msg.match[1], msg.match[2]


### PR DESCRIPTION
My coworkers are using `hubot-schedule` to notify them of meetings and similar, using constructs like `@all` and `@here`. In order for these not to notify everyone in the room when someone runs `schedule list`, I propose an optional configuration parameter that allows the messages to be quoted via `/quote` or whatever is the client-specific way of sending preformatted text.

Example:

```
HUBOT_SCHEDULE_LIST_PREFIX="/quote "
```
